### PR TITLE
Fixed issues where vF registers are overwritten

### DIFF
--- a/Chip8.cpp
+++ b/Chip8.cpp
@@ -160,8 +160,8 @@ void Chip8::runInstruction(char16_t instruction) {
                     //VF is set to 1, otherwise 0. Only the lowest 8 bits of the result are kept, and stored in Vx.
                     uint16_t result = registers[xRegister] + registers[yRegister];
                     if (result > 255) {
-                        registers[VF_REGISTER] = 1;
                         registers[xRegister] = (result & 0xFF);
+                        registers[VF_REGISTER] = 1;
                     } else {
                         registers[xRegister] = result;
                         registers[VF_REGISTER] = 0;
@@ -191,11 +191,12 @@ void Chip8::runInstruction(char16_t instruction) {
                     // Set Vx = Vx SHR 1.
                     //If the least-significant bit of Vx is 1, then VF is set to 1, otherwise 0. Then Vx is divided by 2.
                     if ((registers[xRegister] & 0x01) > 0) {
+                        registers[xRegister] = registers[xRegister] >> 1;
                         registers[VF_REGISTER] = 1;
                     } else {
+                        registers[xRegister] = registers[xRegister] >> 1;
                         registers[VF_REGISTER] = 0;
                     }
-                    registers[xRegister] = registers[xRegister] >> 1;
                     break;
                 }
                 case(7): {
@@ -215,11 +216,12 @@ void Chip8::runInstruction(char16_t instruction) {
                     //Set Vx = Vx SHL 1.
                     //If the most-significant bit of Vx is 1, then VF is set to 1, otherwise to 0. Then Vx is multiplied by 2.
                     if ((registers[xRegister] & 0x80) > 1) {
+                        registers[xRegister] = registers[xRegister] << 1;
                         registers[VF_REGISTER] = 1;
                     } else {
+                        registers[xRegister] = registers[xRegister] << 1;
                         registers[VF_REGISTER] = 0;
                     }
-                    registers[xRegister] = registers[xRegister] << 1;
                     break;
                 }
             }


### PR DESCRIPTION
vF registers used for carry or borrow in sub and addition are being overwritten by values when vX register specified in instructions is the same as vF special register